### PR TITLE
Godot 4.x patch 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
-Voronoi Godot integration
-=========================
+Voronoi Godot integration for Godot 4.x
+=======================================
+
+This fork upgrades the orginal [library](https://github.com/rakai93/godot_voronoi) to support Godot 4.x.
+It compiles against the 3.5 and master branches of [godot](https://github.com/godotengine/godot). 
 
 Integration of [JCash's Voronoi implementation](https://github.com/JCash/voronoi) as a Godot V3.1.1 module.
 
@@ -15,22 +18,38 @@ Example usage
 -----------------
 
 ```gdscript
-# Create voronoi generator
-var generator = Voronoi.new()
-generator.set_points(list_of_vector2)
-# optional: set boundaries for diagram, otherwise boundaries are computed based on points
-generator.set_boundaries(rect2_bounds)
-# optional: relax points N times, resulting in more equal sites
-generator.relax_points(2)
+#VoronoiTest.gd
+extends Node2D
 
-# Generate diagram
-var diagram = generator.generate_diagram()
+var diagram
 
-# Iterate over sites
-for site in diagram.sites():
-	draw_circle(site.center())
+func _ready():
+	# Create voronoi generator	
+	var points = PackedVector2Array([Vector2(0,0)])
+	for i in 100:
+		randomize()
+		points.append(Vector2(randi_range(0, 1000), randi_range(0, 1000)))
+	
+	var generator = Voronoi.new()
+	generator.set_points(points)
+	# optional: set boundaries for diagram, otherwise boundaries are computed based on points
+	#generator.set_boundaries(rect2_bounds)
+	# optional: relax points N times, resulting in more equal sites
+	generator.relax_points(2)
 
-# Iterate over edges
-for edge in diagram.edges():
-	draw_line(edge.start(), edge.end())
+	# Generate diagram
+	diagram = generator.generate_diagram()
+
+func _draw():
+	# Iterate over sites
+	for site in diagram.sites():
+		randomize()
+		var center = site.center()
+		#print("site: ", site, "center: ", center)
+		draw_circle(center, 5,  Color(randf(), randf(), randf()))
+
+	# Iterate over edges
+	for edge in diagram.edges():
+		draw_line(edge.start(), edge.end(), Color.BLACK, 2.0)
+
 ```

--- a/register_types.cpp
+++ b/register_types.cpp
@@ -1,16 +1,18 @@
 #include "register_types.h"
 #include "voronoi.h"
 
-void register_voronoi_types() {
-
-    ClassDB::register_class<Voronoi>();
-    ClassDB::register_class<VoronoiDiagram>();
-    ClassDB::register_class<VoronoiSite>();
-    ClassDB::register_class<VoronoiEdge>();
-
+void initialize_voronoi_module(ModuleInitializationLevel p_level) {
+	if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) {
+		return;
+	}
+	ClassDB::register_class<Voronoi>();
+	ClassDB::register_class<VoronoiDiagram>();
+	ClassDB::register_class<VoronoiSite>();
+	ClassDB::register_class<VoronoiEdge>();
 }
 
-void unregister_voronoi_types() {
-
+void uninitialize_voronoi_module(ModuleInitializationLevel p_level) {
+	if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) {
+		return;
+	}
 }
-

--- a/register_types.h
+++ b/register_types.h
@@ -1,2 +1,4 @@
-void register_voronoi_types();
-void unregister_voronoi_types();
+#include "modules/register_module_types.h"
+
+void initialize_voronoi_module(ModuleInitializationLevel p_level);
+void uninitialize_voronoi_module(ModuleInitializationLevel p_level);

--- a/voronoi.h
+++ b/voronoi.h
@@ -8,10 +8,10 @@
 
 #include <core/math/vector2.h>
 #include <core/math/rect2.h>
-#include <core/object.h>
-#include <core/reference.h>
-#include <core/variant.h>
-#include <core/vector.h>
+#include <core/object/object.h>
+#include <core/object/ref_counted.h>
+#include <core/variant/variant.h>
+#include <core/templates/vector.h>
 
 #include "lib/src/jc_voronoi.h"
 
@@ -102,8 +102,8 @@ protected:
     static void _bind_methods();
 };
 
-class VoronoiDiagram : public Reference {
-    GDCLASS(VoronoiDiagram, Reference)
+class VoronoiDiagram : public RefCounted {
+    GDCLASS(VoronoiDiagram, RefCounted)
 
 public:
     jcv_diagram _diagram;
@@ -126,8 +126,8 @@ protected:
     static void _bind_methods();
 };
 
-class Voronoi : public Reference {
-    GDCLASS(Voronoi, Reference)
+class Voronoi : public RefCounted {
+    GDCLASS(Voronoi, RefCounted)
 
     jcv_rect _boundaries;
     bool _has_boundaries;


### PR DESCRIPTION
This PR Changes the type registration and header paths to play nice with the new Godot 4.x model.

**!** This will break the build for all Godot 3 branches including 3.5. It should build against the [3.x branch](https://github.com/godotengine/godot/tree/3.x).

Build performed on Windows 11 and tested with the script described in README.md (**!** _updated from original_)
